### PR TITLE
Add missing Boost.Filesystem header to mainscreen.C

### DIFF
--- a/src/mainscreen.C
+++ b/src/mainscreen.C
@@ -16,6 +16,7 @@
 #include "editor.h"
 #include "boost/filesystem/operations.hpp"
 #include "boost/filesystem/path.hpp"
+#include "boost/filesystem/directory.hpp"
 #include <physfs.h>
 
 namespace fs = boost::filesystem;


### PR DESCRIPTION
This file uses `fs::directory_iterator` so it needs the relevant header.  This causes a build failure with Boost 1.90.0:

```
src/mainscreen.C: In member function ‘void BTMainScreen::run()’:
src/mainscreen.C:43:6: error: ‘directory_iterator’ is not a member of ‘fs’; did you mean ‘directory_entry’?
   43 |  fs::directory_iterator end_iter;
      |      ^~~~~~~~~~~~~~~~~~
      |      directory_entry
```

(If you could update the package in Rawhide that would be great)